### PR TITLE
Module pattern for views/models/collections

### DIFF
--- a/lib/billy.js
+++ b/lib/billy.js
@@ -57,25 +57,43 @@ function applyGenerators(resources, package, platform, options) {
       controllerGen.sourceFile = resource.router;
       return controllerGen;
     } else if (resource.template) {
+      var filename = config.templatesPath() + resource.template;
       if (loadedTemplates[resource.template]) {
         return;
       } else {
         loadedTemplates[resource.template] = true;
         var generator = function(callback) {
-          templateUtil.loadTemplate(resource.template, config.templateCache(), callback);
+          templateUtil.loadTemplate(filename, config.templateCache(), callback);
         };
-        generator.sourceFile = resource.template;
+        generator.sourceFile = filename;
         return generator;
       }
-    } else if (typeof resource === 'string' && resource.match(/(^|\/)(views|models|collections)\/(.+)$/)) {
-      return (function(resource){
-        var moduleMatch = resource.match(/(^|\/)(views|models|collections)\/(.+)$/);
-        var moduleGenerator = function(callback) {
-          var type = moduleMatch[2].charAt(0).toUpperCase() + moduleMatch[2].slice(1);
-          templateUtil.loadModule(resource, moduleMatch[3].replace(/\.js$/, ''), config.namespace(), type, callback);
+    } else if (resource.model) {
+      return (function(resource) {
+        var filename = config.modelsPath() + resource.model;
+        var modelGenerator = function(callback) {
+          templateUtil.loadModule(config.modelsNamespace(), resource.model.replace(/\.js$/, ''), filename, callback);
         };
-        moduleGenerator.sourceFile = resource;
-        return moduleGenerator;
+        modelGenerator.sourceFile = filename;
+        return modelGenerator;
+      })(resource);
+    } else if (resource.collection) {
+      return (function(resource) {
+        var filename = config.collectionsPath() + resource.collection;
+        var collectionGenerator = function(callback) {
+          templateUtil.loadModule(config.collectionsNamespace(), resource.collection.replace(/\.js$/, ''), filename, callback);
+        };
+        collectionGenerator.sourceFile = filename;
+        return collectionGenerator;
+      })(resource);
+    } else if (resource.view) {
+      return (function(resource) {
+        var filename = config.viewsPath() + resource.view;
+        var viewGenerator = function(callback) {
+          templateUtil.loadModule(config.viewsNamespace(), resource.view.replace(/\.js$/, ''), filename, callback);
+        };
+        viewGenerator.sourceFile = filename;
+        return viewGenerator;
       })(resource);
     } else {
       return resource;
@@ -106,8 +124,11 @@ exports.init = function(configFile, options) {
     function buildPlatform(package, platform, callback) {
       var modules = config.moduleList(package),
           allResources = config.combineModules(package) && [];
-      modules.forEach(function(module) {
-        buildModule(package, platform, module, allResources, callback)
+      modules.forEach(function(module, i) {
+        //help prevent too many open files (fs.*sync methods don't really appear to be sync when it comes to closing file descriptors)
+        setTimeout(function(){
+          buildModule(package, platform, module, allResources, callback);
+        }, i * 100);
       });
 
       if (allResources) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,5 +1,6 @@
 var fs = require('fs'),
     fu = require('./fileUtil'),
+    path = require('path'),
     templateUtil = require('./templateUtil');
 
 var config, packageList, moduleList;
@@ -21,6 +22,78 @@ function loadModuleList() {
   }
 }
 
+function templatesListByViewNameFromModuleName(moduleName) {
+  var list = {},
+    templates = config.templates,
+    module = config.modules[moduleName],
+    views = module.views || [];
+
+  //add implicit path to views list, and list files in directories 
+  if (path.existsSync(exports.viewsPath() + moduleName) && views.indexOf(moduleName) === -1) {
+    views.push(moduleName);
+  }
+  views.forEach(function(view) {
+    if (fu.isDirectory(exports.viewsPath() + view)) {
+      fu.filesWithExtension(exports.viewsPath() + view, /\.(js|json)/).forEach(function(view) {
+        view = view.substring(exports.viewsPath().length, view.length);
+        if (views.indexOf(view) === -1) {
+          views.push(view);
+        }
+      });
+    }
+  });
+
+  //remove directories
+  views = views.filter(function(view) {
+    return !fu.isDirectory(exports.viewsPath() + view);
+  });
+
+  //views array is now built, build template list
+  views.forEach(function(view) {
+    //add templates specified in config
+    list[view] = templates[view] || [];
+    
+    //add template matching filename if exists
+    if (path.existsSync(exports.templatesPath() + view.replace(/\.js$/, '.handlebars'))) {
+      var template_to_add = view.replace(/\.js$/, '.handlebars');
+      if (list[view].indexOf(template_to_add) === -1) {
+        list[view].push(template_to_add);
+      }
+    } else if (path.existsSync(exports.templatesPath() + view.replace(/\.js$/, '.hb'))) {
+      var template_to_add = view.replace(/\.js$/, '.hb');
+      if (list[view].indexOf(template_to_add) === -1) {
+        list[view].push(template_to_add);
+      }
+    }
+
+    //add files in implicit directory if exists
+    var implicit_teplate_path = exports.templatesPath() + view.replace(/\.js$/, '');
+    if (path.existsSync(implicit_teplate_path)) {
+      fu.filesWithExtension(implicit_teplate_path, /\.(hb|handlebars)$/).forEach(function(template) {
+        var template_to_add = template.substring(exports.templatesPath().length, template.length);
+        if (list[view].indexOf(template_to_add) === -1) {
+          list[view].push(template_to_add);
+        }
+      });
+    }
+    
+    //add files matching name-*.handlebars or name_*.handlebars
+    var templates_dir = path.dirname(exports.templatesPath() + view.replace(/\.js$/, ''));
+    fs.readdirSync(templates_dir).forEach(function(template) {
+      var template_name = path.basename(template);
+      var tester = new RegExp(path.basename(view.replace(/\.js$/, '')) + '(-|_).+\\.(hb|handlebars)$');
+      if (tester.exec(template_name)) {
+        var template_to_add = templates_dir.substring(exports.templatesPath().length, templates_dir.length) + '/' + template;
+        if (list[view].indexOf(template_to_add) === -1) {
+          list[view].push(template_to_add);
+        }
+      }
+    });
+  });
+
+  return list;
+}
+
 exports.load = function(path) {
   var data = fs.readFileSync(path, 'utf8');
 
@@ -37,15 +110,51 @@ exports.load = function(path) {
 exports.namespace = function() {
   return config.namespace || 'Application';
 };
+
+exports.modelsNamespace = function() {
+  return config.modelsNamespace || exports.namespace() + '.Models';
+};
+
+exports.viewsNamespace = function() {
+  return config.viewsNamespace || exports.namespace() + '.Views';
+};
+
+exports.collectionsNamespace = function() {
+  return config.collectionsNamespace || exports.namespace() + '.Collections';
+};
+
+exports.templatesPath = function() {
+  return config.templatesPath || 'templates/';
+};
+
+exports.viewsPath = function() {
+  return config.modelsPat || 'js/views/';
+};
+
+exports.modelsPath = function() {
+  return config.modelsPath || 'js/models/';
+};
+
+exports.collectionsPath = function() {
+  return config.collectionsPath || 'js/collections/';
+};
+
+exports.routersPath = function() {
+  return config.routersPath || 'js/routers/';
+};
+
 exports.moduleMap = function() {
   return config.moduleMap || exports.namespace() + '.moduleMap';
 };
+
 exports.loadPrefix = function() {
   return config.loadPrefix || '';
 };
+
 exports.templateCache = function() {
   return config.templateCache || exports.namespace() + '.templateCache';
 };
+
 exports.packageConfig = function() {
   return config.packageConfig || exports.namespace() + '.packageConfig';
 };
@@ -57,6 +166,7 @@ exports.packageList = function() {
 exports.combineModules = function(package) {
   return config.packages[package].combine;
 };
+
 exports.platformList = function(package) {
   if (!package) {
     return config.platforms || [''];
@@ -73,15 +183,17 @@ exports.routeList = function(module) {
   return config.modules[module].routes;
 };
 
+exports.modules = function() {
+  return config.modules;
+};
+
 exports.fileList = function(module, platform) {
+  var moduleName = module;
   module = config.modules[module];
+  var templates = templatesListByViewNameFromModuleName(moduleName),
+      ret = [];
 
-  var views = config.views,
-      ret = [],
-
-      files = module.support || module;
-
-  var iterator = function(resource) {
+  var iterator = function(resource, type) {
     if (resource.src) {
       var found;
       if (resource.platform) {
@@ -106,29 +218,66 @@ exports.fileList = function(module, platform) {
       ret.push({ map: true });
     } else if (resource === 'package_config.json') {
       ret.push({ packageConfig: true });
+    } else if (type) {
+      var value = {};
+      //singularize type ({model: value} instead of {models: value})
+      value[type.replace(/s$/, '')] = resource;
+      ret.push(value);
     } else {
       ret.push(resource);
     }
 
-    if (views[resource]) {
-      views[resource].forEach(function(template) {
+    if (templates[resource]) {
+      templates[resource].forEach(function(template) {
         ret.push({ template: template });
       });
     }
   };
 
+  //support files / module that is only a file list
+  var files = module.support || module;
   for (var i = 0, len = files.length; i < len; i++) {
     if(fu.isDirectory(files[i])) {
-      fu.filesWithExtension(files[i],/\.(js|json)/).forEach(iterator);
+      fu.filesWithExtension(files[i],/\.(js|json)/).forEach(function(file){
+        iterator(file);
+      });
     } else {
       iterator(files[i]);
     }
   }
 
+  //views / models / collections
+  ['views','models','collections'].forEach(function(type) {
+    var files = module[type] ? [].concat(module[type]) : [];
+    if (path.existsSync(exports[type + 'Path']() + moduleName) && files.indexOf(moduleName) === -1) {
+      files.push(moduleName);
+    }
+    files.forEach(function(file) {
+      if(fu.isDirectory(exports[type + 'Path']() + file)) {
+        fu.filesWithExtension(exports[type + 'Path']() + file,/\.(js|json)/).forEach(function(file) {
+          iterator(file.substring(exports[type + 'Path']().length, file.length), type);
+        });
+      } else {
+        iterator(file, type);
+      }
+    });
+  });
+
   // Generate the controller if we have the info for it
-  if (module.router || module.controller) {
-    ret.push({ router: module.router || module.controller, routes: module.routes });
+  var router = module.router || module.controller;
+  if (!router) {
+    var test_path = exports.routersPath() + moduleName + '.js';
+    if (path.existsSync(test_path)) {
+      router = test_path;
+    }
   }
+  if (router) {
+    ret.push({ router: router, routes: module.routes });
+  }
+
+  //console.log('========');
+  //console.log(ret);
+  //console.log('++++++++');
 
   return ret;
 };

--- a/lib/module.handlebars
+++ b/lib/module.handlebars
@@ -6,6 +6,6 @@
   })();
   if (typeof module.exports !== 'undefined') {
     module.exports.name = '{{{name}}}';
-    {{namespace}}.{{type}}['{{{name}}}'] = module.exports;
+    {{namespace}}['{{{name}}}'] = module.exports;
   }
 })();

--- a/lib/templateUtil.js
+++ b/lib/templateUtil.js
@@ -37,12 +37,14 @@ exports.setTemplateTemplate = function(template) {
 exports.setControllerTemplate = function(path) {
     controllerTemplate = hbs.compile(fs.readFileSync(path, 'utf8'));
 };
+
 exports.getControllerTemplate = function() {
     if (!controllerTemplate) {
         exports.setControllerTemplate(__dirname + '/controller.handlebars');
     }
     return controllerTemplate;
 };
+
 exports.getModuleMapTemplate = function() {
     if (!moduleMapTemplate) {
         moduleMapTemplate = hbs.compile(fs.readFileSync(__dirname + '/moduleMap.handlebars', 'utf8'));
@@ -80,6 +82,7 @@ exports.loadController = function(name, routes, callback) {
         );
     });
 };
+
 exports.loadModuleMap = function(map, mapper, loadPrefix, callback) {
     var moduleMapTemplate = exports.getModuleMapTemplate();
     callback(
@@ -92,7 +95,7 @@ exports.loadModuleMap = function(map, mapper, loadPrefix, callback) {
     );
 };
 
-exports.loadModule = function(fileName, name, namespace, type, callback) {
+exports.loadModule = function(namespace, name, fileName, callback) {
     var moduleTemplate = exports.getModuleTemplate();
     fs.readFile(fileName, "utf8", function(err, data) {
         if (err) {
@@ -105,7 +108,6 @@ exports.loadModule = function(fileName, name, namespace, type, callback) {
                 fileName: exports.escapeJsString(fileName),
                 name: exports.escapeJsString(name),
                 namespace: namespace,
-                type: type,
                 moduleContents: data
             })
         );


### PR DESCRIPTION
Wraps views/models/collections in a module pattern.
- would close https://www.pivotaltracker.com/story/show/17761365  IMHO we should not auto wrap non controller/view/model/collection files in a module
- backwards compatible with current Phoenix code (no effect if nothing exported from file)
- removes the need to declare a "name" property inside models/views/collections
- removes need to declare class names Phoenix.Models.CheckoutCreditCard -> Phoenix.Models['checkout/credit-card']
