### PR TITLE
Conditional Plugin 

### DIFF
--- a/lib/plugins/conditional.js
+++ b/lib/plugins/conditional.js
@@ -35,7 +35,6 @@ function plugin(options) {
       if (found) {
         complete(undefined, []);
       } else {
-        //complete(undefined, [context.resource]);
         next(complete);
       }
     }


### PR DESCRIPTION
This plugin selectively removes resources from a module based on command line arguments you pass in. For example if you run the following from our examples directory, the zepto.js will not be included in the base module. 

``` bash
$ ../bin/lumbar --config config/dev.json --use ../lib/plugins/conditional --with {env:\'dev\'} public
```
