### PR TITLE
all plugins to use fileUtil through a context reference

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -15,6 +15,8 @@ function Context(options, config, plugins, event) {
   this.event = event || options.event;
 }
 Context.prototype = {
+  fileUtil: fu,
+
   clone: function() {
     var ret = new Context(this, this.config);
     ret.parent = this;

--- a/lib/plugins/inline-styles.js
+++ b/lib/plugins/inline-styles.js
@@ -1,5 +1,3 @@
-var fu = require('../fileUtil');
-
 function isInline(context) {
   return (context.config.attributes.styles || {}).inline;
 }

--- a/lib/plugins/module-map.js
+++ b/lib/plugins/module-map.js
@@ -1,19 +1,18 @@
 var _ = require('underscore'),
     async = require('async'),
-    fu = require('../fileUtil'),
     handlebars = require('handlebars');
 
 var moduleMapTemplate;
 
-function getModuleMapTemplate() {
+function getModuleMapTemplate(fileUtil) {
   if (!moduleMapTemplate) {
-    moduleMapTemplate = handlebars.compile(fu.readFileSync(__dirname + '/module-map.handlebars'));
+    moduleMapTemplate = handlebars.compile(fileUtil.readFileSync(__dirname + '/module-map.handlebars'));
   }
   return moduleMapTemplate;
 };
 
-function loadModuleMap(map, mapper, loadPrefix, callback) {
-  var moduleMapTemplate = getModuleMapTemplate();
+function loadModuleMap(map, mapper, loadPrefix, fileUtil, callback) {
+  var moduleMapTemplate = getModuleMapTemplate(fileUtil);
   callback(
     undefined,
     moduleMapTemplate({
@@ -191,7 +190,7 @@ module.exports = {
           } else {
             var moduleMap = config.attributes.moduleMap || 'module.exports.moduleMap';
             stripPrefix(map, context.fileCache.commonFilePrefix);
-            loadModuleMap(map, moduleMap, config.loadPrefix() + context.fileCache.commonFilePrefix, function(err, data) {
+            loadModuleMap(map, moduleMap, config.loadPrefix() + context.fileCache.commonFilePrefix, context.fileUtil, function(err, data) {
               callback(err, data && {data: data, noSeparator: true});
             });
           }

--- a/lib/plugins/package-config.js
+++ b/lib/plugins/package-config.js
@@ -1,15 +1,14 @@
-var fu = require('../fileUtil'),
-    handlebars = require('handlebars');
+var handlebars = require('handlebars');
 
 const DEFAULT_CONFIG_TEMPLATE = "{{{name}}} = {{{data}}};\n";
 var packageConfigTemplate = handlebars.compile(DEFAULT_CONFIG_TEMPLATE);
 
-function loadPackageConfig(name, configFile, callback) {
+function loadPackageConfig(name, configFile, fileUtil, callback) {
   if (!configFile) {
     return callback(new Error('package_config.json specified without file being set'));
   }
 
-  fu.readFile(configFile, function(err, data) {
+  fileUtil.readFile(configFile, function(err, data) {
     if (err) {
       callback(err);
       return;
@@ -37,7 +36,7 @@ module.exports = {
     if (resource['package-config']) {
       var packageConfigGen = function(context, callback) {
         var packageConfig = config.attributes.packageConfig || 'module.exports.config';
-        loadPackageConfig(packageConfig, options.packageConfigFile, function(err, data) {
+        loadPackageConfig(packageConfig, options.packageConfigFile, context.fileUtil, function(err, data) {
           callback(err, data && {data: data, noSeparator: true});
         });
       };

--- a/lib/plugins/router.js
+++ b/lib/plugins/router.js
@@ -1,5 +1,4 @@
-var fu = require('../fileUtil'),
-    handlebars = require('handlebars');
+var handlebars = require('handlebars');
 
 const TEMPLATE = "/* router : {{{name}}} */\nmodule.name = \"{{{name}}}\";\nmodule.routes = {{{routes}}};\n";
 var routerTemplate = handlebars.compile(TEMPLATE);

--- a/lib/plugins/static-output.js
+++ b/lib/plugins/static-output.js
@@ -1,5 +1,4 @@
-var async = require('async'),
-    fu = require('../fileUtil');
+var async = require('async');
 
 module.exports = {
   mode: 'static',
@@ -23,7 +22,7 @@ module.exports = {
                 resource: resource
               };
 
-              fu.writeFile(fileContext.fileName, data.content, function(err) {
+              context.fileUtil.writeFile(fileContext.fileName, data.content, function(err) {
                 callback(err, ret);
               });
             },

--- a/lib/plugins/stylus.js
+++ b/lib/plugins/stylus.js
@@ -1,5 +1,4 @@
 var _ = require('underscore'),
-    fu = require('../fileUtil'),
     inlineStyles = require('./inline-styles'),
     nib = require('nib'),
     path = require('path'),
@@ -19,7 +18,7 @@ function compile(files, context, callback) {
     .set('filename', files.join(';'))
     .set('compress', context.options.minimize)
     .include(nib.path)
-    .include(fu.lookupPath())
+    .include(context.fileUtil.lookupPath())
     .use(nib)
     .use(stylusImages({
       outdir: path.dirname(context.fileName),
@@ -30,21 +29,21 @@ function compile(files, context, callback) {
 
 
   if (styleConfig.styleRoot) {
-    compiler.include(fu.resolvePath(styleConfig.styleRoot));
+    compiler.include(context.fileUtil.resolvePath(styleConfig.styleRoot));
   }
 
   context.config.platformList().forEach(function(platform) {
     compiler.define('$' + platform, platform === context.platform ? stylus.nodes.true : stylus.nodes.false);
   });
 
-  fu.ensureDirs(context.fileName, function(err) {
+  context.fileUtil.ensureDirs(context.fileName, function(err) {
     if (err) {
       return callback(err);
     }
 
     try {
       compiler.render(function(err, data) {
-        var lookupPath = fu.lookupPath(),
+        var lookupPath = context.fileUtil.lookupPath(),
             inputs = compiler.options._imports
                 .map(function(file) { return file.path; })
                 .filter(function(file) { return file.indexOf(lookupPath) === 0; });

--- a/lib/plugins/template.js
+++ b/lib/plugins/template.js
@@ -1,5 +1,4 @@
 var _ = require('underscore'),
-    fu = require('../fileUtil'),
     handlebars = require('handlebars'),
     templateUtil = require('../templateUtil');
 
@@ -9,7 +8,7 @@ var templateTemplate = handlebars.compile(DEFAULT_TEMPLATE_TEMPLATE),
     precompiledTemplate = handlebars.compile(PRECOMPILED_TEMPLATE);
 
 function loadTemplate(name, context, callback) {
-  fu.readFile(name, function(err, data) {
+  context.fileUtil.readFile(name, function(err, data) {
     if (err) {
       callback(err);
       return;
@@ -95,7 +94,7 @@ module.exports = {
         var generator = function(buildContext, callback) {
           var output = [],
               inputs = [];
-          fu.fileList(resource.template, /\.handlebars$/, function(err, files) {
+          context.fileUtil.fileList(resource.template, /\.handlebars$/, function(err, files) {
             if (err) {
               callback(err);
               return;

--- a/lib/plugins/update-externals.js
+++ b/lib/plugins/update-externals.js
@@ -1,7 +1,6 @@
 var _ = require('underscore'),
     async = require('async'),
-    jsdom = require('jsdom').jsdom,
-    fu = require('../fileUtil');
+    jsdom = require('jsdom').jsdom;
 
 module.exports = {
   priority: 50,
@@ -60,7 +59,7 @@ module.exports = {
       next(function(err, resource) {
         function generator(context, callback) {
           // Load the source data
-          fu.loadResource(context, resource, function(err, file) {
+          context.loadResource(resource, function(err, file) {
             if (err) {
               return complete(err);
             }


### PR DESCRIPTION
Since fileUtil is stateful (lookupPath) we need to ensure that all custom plugins reference the same instance of that object.

I will also go back and update the docs but it isn't part of this pull request because there are other updates as well to come.
