### PR TITLE
Thorax plugin

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -3,7 +3,7 @@ var _ = require('underscore'),
 const corePlugins = [
     'styles-output', 'scripts-output', 'static-output',
     'scope', 'router', 'template', 'inline-styles', 'stylus', 'module-map', 'package-config', 'update-externals',
-    'inline-styles-resources', 'styles', 'scripts', 'static'];
+    'inline-styles-resources', 'styles', 'scripts', 'static', 'thorax'];
 var fileUtils = require("./fileUtil");
 
 var globalPlugins = {};
@@ -28,6 +28,7 @@ exports.plugin('static', require('./plugins/static.js'));
 exports.plugin('styles-output', require('./plugins/styles-output.js'));
 exports.plugin('scripts-output', require('./plugins/scripts-output.js'));
 exports.plugin('static-output', require('./plugins/static-output.js'));
+exports.plugin('thorax', require('./plugins/thorax.js'));
 
 exports.create = function(options) {
   var plugins;

--- a/lib/plugins/thorax.js
+++ b/lib/plugins/thorax.js
@@ -1,0 +1,94 @@
+var path = require('path'),
+    fs = require('fs'),
+    fu = require('./../fileUtil'),
+    cwd = process.cwd(),
+    thoraxConfig = JSON.parse(fu.readFileSync(path.join(cwd, 'thorax.json')));
+
+module.exports = {
+  priority: 2,
+  mode: ['scripts', 'styles'],
+  moduleResources: function(context, next, complete) {
+    next(function(err, ret) {
+      if (err) {
+        return complete(err);
+      }
+      if (context.mode === 'styles') {
+        addToPayload(ret, path.join(thoraxConfig.paths.styles, context.module.name + '.styl'));
+      } else if (context.mode === 'scripts') {
+        var moduleViews = path.join(thoraxConfig.paths.views, context.module.name);
+        [
+          path.join(thoraxConfig.paths.models, context.module.name),
+          path.join(thoraxConfig.paths.collections, context.module.name),
+          moduleViews,
+          path.join(thoraxConfig.paths.routers, context.module.name + '.js')
+        ].forEach(function(filePath) {
+          addToPayload(ret, filePath)
+        });
+        //add templates
+        readdirSync(path.join(cwd, moduleViews), function(err, results) {
+          results && results.forEach(function(result) {
+            var viewName = result.substring(cwd.length + 1, result.length),
+                templateName = path.join(thoraxConfig.paths.templates, viewName.substring(thoraxConfig.paths.views.length + 1, viewName.length)).replace(/\.\w+$/, '');
+            [
+              templateName + '.handlebars',
+              templateName + '-item.handlebars',
+              templateName + '-empty.handlebars'
+            ].forEach(function(templatePath) {
+              if (path.existsSync(path.join(cwd, templatePath)) && !detectTemplate(ret, templatePath)) {
+                ret.push({template: templatePath});
+                console.log('added',templatePath,'to',viewName);
+              }
+            });
+          });
+        });
+      }
+      complete(undefined, ret);
+    });
+  }
+};
+
+function addTemplatesForScript(ret, script) {
+
+}
+
+function detectTemplate(ret, template) {
+  for (var i = 0; i < ret.length; ++i) {
+    var item = ret[i];
+    if (item && item.template && item.template === template) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function addToPayload(ret, filePath) {
+  if (ret && ret.indexOf(filePath) === -1 && path.existsSync(path.join(cwd, filePath))) {
+    console.log('added', filePath);
+    ret.push(filePath);
+  }
+}
+
+function readdirSync(dir, done) {
+  var results = [];
+  fs.readdir(dir, function(err, list) {
+    if (err) return done(err);
+    var i = 0;
+    (function next() {
+      var file = list[i++];
+      if (!file) return done(null, results);
+      file = dir + '/' + file;
+      fs.stat(file, function(err, stat) {
+        if (stat && stat.isDirectory()) {
+          readdirSync(file, function(err, res) {
+            results = results.concat(res);
+            next();
+          });
+        } else {
+          results.push(file);
+          next();
+        }
+      });
+    })();
+  });
+}
+


### PR DESCRIPTION
Kevin, this is not ready for a merge but I wanted to start a discussion on this.  This plugin attempts to add the following resources to the config automatically (only if the file / directory exists):

per module:

```
"styles": [
  "{{pathToStyles}}/{{moduleName}}.styl"
],
"scripts": [
  "{{pathToModels}}/{{moduleName}}",
  "{{pathToCollections}}/pharmacy",
  "{{pathToViews}}/{{moduleName}}",
  "{{pathToRouters}}/{{moduleName}}.js"
]
```

per view:

```
"js/views/module/view.js": [
  "templates/module/view.handlebars",
  "templates/module/view-item.handlebars",
  "templates/module/view-empty.handlebars"
]
```

The module side of things is working like a charm, but I can't get the templates to be picked up. I've tried modifying using the resourceList and got this error "Scoped files may not appear before global files" no matter if I used push, or unshift. I also tried modifying the module.config.attributes directly, but that didn't work either. Can you provide an example of how to modify the templates array?

In terms of using this in Phoenix, the following entries would be generated by this plugin that are not already present:
- styles/components/taxonomy.styl (needs name change since the taxonomy module doesn't actually load it)
- js/views/qr (ok, can remove existing declarations)
- js/views/location (ok, probably need to include js/views/location/base.js first)
- js/models/pharmacy (ok)
- js/views/pharmacy (ok)

All of the other script and style declarations that this plugin would generate are already present in the manually generated file and would become optional after this plugin was running. No modification would be required at all to the templates configuration. About 50% of the template configuration conforms exactly to what this plugin would generate and could be removed.
