### PR TITLE
add without-extension helper

### DIFF
--- a/lib/plugins/template.js
+++ b/lib/plugins/template.js
@@ -4,6 +4,10 @@ var _ = require('underscore'),
     fu = require('../fileUtil'),
     templateUtil = require('../templateUtil');
 
+handlebars.registerHelper('without-extension', function(str) {
+  return str.replace(/\.[a-zA-Z0-9]+$/, '');
+});
+
 const DEFAULT_TEMPLATE_TEMPLATE = "/* handsfree : {{{name}}}*/\n{{{templateCache}}}['{{{name}}}'] = Handlebars.compile('{{{data}}}');\n";
 const PRECOMPILED_TEMPLATE = "/* handsfree : {{{name}}}*/\n{{{templateCache}}}['{{{name}}}'] = Handlebars.template({{{data}}});\n";
 


### PR DESCRIPTION
For thorax we want to remove the file extension so I added this helper, in the thorax boilerplate lumbar.json this is what it looks like:

```
"templates": {
  "template": "Application.templates['{{{without-extension name}}}'] = '{{{data}}}';",
```

Another approach would be to add a "nameWithoutExtension" var. Let me know which you prefer.

~ Ryan
