### PR TITLE
Require underscore in coffeescript plugin

### DIFF
--- a/lib/plugins/coffee-script.js
+++ b/lib/plugins/coffee-script.js
@@ -1,6 +1,7 @@
 var CoffeeScript = require('coffee-script'),
     path = require('path'),
-    fu = require('../fileUtil');
+    fu = require('../fileUtil'),
+    _ = require('underscore');
 
 module.exports = {
   mode: 'scripts',


### PR DESCRIPTION
Uses `_.extend` but didn't include underscore
