### PR TITLE
Use temp file for stylus worker callback

### DIFF
--- a/lib/plugins/stylus-worker.js
+++ b/lib/plugins/stylus-worker.js
@@ -6,7 +6,8 @@ var _ = require('underscore'),
     path = require('path'),
       join = path.join,
       normalize = path.normalize,
-    resources = require('../util/resources');
+    resources = require('../util/resources')
+    tmp = require('tmp');
 
 var stylus = stylusImages.stylus || require('stylus');
 
@@ -25,8 +26,21 @@ process.on('message', function(msg) {
   if (msg.type === 'cache:reset') {
     fu.emit('cache:reset', msg.path);
   } else {
-    exec(msg, function(err, data) {
-      return process.send({err: err, stack: err && err.stack, data: data});
+    exec(msg, function stylusComplete(err, data) {
+      if (err) {
+        return process.send({err: err, stack: err && err.stack});
+      } else {
+        tmp.file(function(err, path, fd) {
+          if (err) {
+            return process.send({err: err, stack: err && err.stack});
+          }
+
+          fs.writeSync(fd, JSON.stringify(data));
+          fs.closeSync(fd);
+
+          return process.send({data: path});
+        });
+      }
     });
   }
 });

--- a/lib/plugins/stylus.js
+++ b/lib/plugins/stylus.js
@@ -24,6 +24,7 @@ var _ = require('underscore'),
     inlineStyles = require('./inline-styles'),
     path = require('path'),
       normalize = path.normalize,
+    fs = require('fs'),
     fu = require('../fileUtil'),
     resources = require('../util/resources');
 
@@ -286,6 +287,9 @@ module.exports = {
               if (err) {
                 data = undefined;
               }
+
+              data = JSON.parse(fs.readFileSync(data).toString());
+
               _.each(queue, function(callback) {
                 callback.callback(err, response(data, callback.density));
               });

--- a/package.json
+++ b/package.json
@@ -21,14 +21,15 @@
     "bower": "~0.9.2",
     "cheerio": "~0.12",
     "child-pool": "~1.0.0",
+    "coffee-script": "~1.6",
     "esprima": "~1.0",
+    "estraverse": "~1.1.2",
     "growl": "~1.7",
-    "handlebars": "1.0.12",
+    "handlebars": "~1.1.0",
     "nib": "~0.9",
     "stylus": "0.36.1",
     "stylus-images": "1.0.3",
-    "coffee-script": "~1.6",
-    "estraverse": "~1.1.2",
+    "tmp": "0.0.21",
     "underscore": "~1.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Operates more efficiently than direct IPC serialization.
