### PR TITLE
2 phase build

### DIFF
--- a/lib/lumbar.js
+++ b/lib/lumbar.js
@@ -61,7 +61,13 @@ exports.init = function(lumbarFile, options) {
           return;
         }
 
-        stateMachine.buildPlatform(watchContext.clone(status), logError);
+        stateMachine.loadPlatform(watchContext.clone(status), function(err, contexts) {
+          if (err) {
+            return logError(err);
+          }
+
+          stateMachine.buildContexts(contexts, logError);
+        });
       });
     }
 

--- a/lib/state-machine.js
+++ b/lib/state-machine.js
@@ -86,6 +86,21 @@ exports.buildPackages = function(rootContext, packageName, modules, callback) {
     modules = undefined;
   }
 
+  exports.loadPackages(rootContext, packageName, modules, function(err, contexts) {
+    if (err) {
+      return callback(err);
+    }
+
+    exports.buildContexts(contexts, callback);
+  });
+};
+
+exports.loadPackages = function(rootContext, packageName, modules, callback) {
+  if (!callback) {
+    callback = modules;
+    modules = undefined;
+  }
+
   // Allow a string or a list as modules input
   if (!_.isArray(modules)) {
     modules = [modules];
@@ -120,58 +135,96 @@ exports.buildPackages = function(rootContext, packageName, modules, callback) {
     });
   });
 
-  async.forEach(contexts, exports.buildPlatform, callback);
+  var ret = {};
+  async.forEach(
+    contexts,
+    function(context, callback) {
+      exports.loadPlatform(context, function(err, contexts) {
+        if (!err) {
+          var pkg = ret[context.package] = ret[context.package] || {};
+          pkg[context.platform] = _.flatten(contexts);
+        }
+        return callback(err);
+      });
+    },
+    function(err) {
+      callback(err, ret);
+    });
 };
-exports.buildPlatform = function(context, callback) {
-  context.event.emit('debug', 'Build platform: ' + context.description);
+
+exports.loadPlatform = function(context, callback) {
+  context.event.emit('debug', 'Load platform: ' + context.description);
   var modes = context.mode ? [context.mode] : context.plugins.modes();
 
-  async.forEach(modes, function(mode, callback) {
-      exports.buildMode(mode, context, callback);
+  async.map(modes, function(mode, callback) {
+      exports.loadMode(mode, context, callback);
     },
-    callback);
+    function(err, contexts) {
+      callback(err, contexts && _.flatten(contexts));
+    });
 };
-exports.buildMode = function(mode, context, callback) {
-  context.event.emit('debug', 'Build mode: ' + context.description);
 
-  var modules = context.module ? [context.module] : context.config.moduleList(context.package);
+exports.loadMode = function(mode, context, callback) {
+  context.event.emit('debug', 'Load mode: ' + context.description);
 
   context = context.clone();
   context.mode = mode;
   context.modeCache = {};
 
   if (context.fileConfig) {
-    processFileConfig(context.fileConfig, callback);
+    callback(undefined, [processFileConfig(context.fileConfig)]);
   } else {
     context.plugins.outputConfigs(context, function(err, configs) {
       if (err) {
         return callback(err);
       }
-      async.forEach(configs, processFileConfig, callback);
+
+      callback(undefined, _.map(configs, processFileConfig));
     });
   }
 
-  function processFileConfig(fileConfig, callback) {
+  function processFileConfig(fileConfig) {
     var fileContext = context.clone(true);
     fileContext.fileConfig = fileConfig;
-    fileContext.resources = [];
-    fileContext.combineResources = {};
-    fileContext.fileCache = fileContext.combined ? {} : undefined;
 
-    async.forEach(modules, function(module, callback) {
-      var moduleContext = fileContext.clone();
-      moduleContext.module = module;
-
-      exports.buildModule(moduleContext, callback);
-    },
-    function(err) {
-      if (err) {
-        return callback(err);
-      }
-
-      context.plugins.modeComplete(fileContext, callback);
-    });
+    return fileContext;
   }
+};
+
+exports.buildContexts = function(configContexts, callback) {
+  if (configContexts instanceof Context) {
+    configContexts = [configContexts];
+  } else if (!_.isArray(configContexts)) {
+    configContexts = _.map(configContexts, function(package) {
+      return _.values(package);
+    });
+    configContexts = _.flatten(configContexts);
+  }
+
+  async.forEach(
+    configContexts,
+    function(fileContext, callback) {
+        var modules = fileContext.module ? [fileContext.module] : fileContext.config.moduleList(fileContext.package);
+
+        fileContext.resources = [];
+        fileContext.combineResources = {};
+        fileContext.fileCache = fileContext.combined ? {} : undefined;
+
+        async.forEach(modules, function(module, callback) {
+          var moduleContext = fileContext.clone();
+          moduleContext.module = module;
+
+          exports.buildModule(moduleContext, callback);
+        },
+        function(err) {
+          if (err) {
+            return callback(err);
+          }
+
+          fileContext.plugins.modeComplete(fileContext, callback);
+        });
+      },
+      callback);
 };
 
 exports.buildModule = function(context, callback) {


### PR DESCRIPTION
Splits the build actions into context generation and the actual build steps that (could) output files.

This change allows for more atomic utility methods that can easily be implemented as grunt tasks and external APIs.
